### PR TITLE
Exclude 3rd Party Libs by Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The command line arguments have been completely reworked for 2.x. Arguments are 
 ```
 FodUpload.jar -u <url> -z <file> -ac <key> <secret> | -uc <username> <password> -ep <1|SingleScan|2|Subscription>
 [-purchase] [-b] [-I <minutes>] [-p <1|Standard|2|Express>] [-a <1|Manual|2|Automated>] 
-[-P <proxyUrl> <username> <password> <ntDomain> <ntWorkstation>] [-x] [-s] [-r] [-h] [-v]
+[-P <proxyUrl> <username> <password> <ntDomain> <ntWorkstation>] [-itp] [-s] [-r] [-h] [-v]
 ```
 
 Each option has a short and long name:
@@ -29,7 +29,7 @@ Short Name | Long Name              | Required? | Description
  -s        | -runSonatypeScan       | No        | Whether to run a Sonatype Scan         
  -h        | -help                  | No        | Print help dialog                                                
  -v        | -version               | No        | Print jar version   
- -x        | -excludeThirdPartyLibs | No        | Exclude Third Party Librarys from scan 
+ -itp      | -includeThirdPartyLibs | No        | Include Third Party Libraries from scan
  -r        | -isRemediationScan     | No        | Whether the scan is in remediation 
  -b        | -isBundledAssessment   | No        | Whether the scan is a bundled assessment
  -purchase | -purchaseEntitlement   | No		| Whether to purchase an entitlement (if available)

--- a/src/main/java/com/fortify/fod/fodapi/controllers/StaticScanController.java
+++ b/src/main/java/com/fortify/fod/fodapi/controllers/StaticScanController.java
@@ -66,7 +66,7 @@ public class StaticScanController extends ControllerBase {
                 fragUrl += "&auditPreferenceType=" + fc.auditPreferenceType.toString();
             fragUrl += "&doSonatypeScan=" + fc.runSonatypeScan;
             fragUrl += "&isRemediationScan=" + fc.isRemediationScan;
-            fragUrl += "&excludeThirdPartyLibs=" + fc.excludeThirdPartyLibs;
+            fragUrl += "&excludeThirdPartyLibs=" + !fc.includeThirdPartyLibs;
 
             Gson gson = new Gson();
 

--- a/src/main/java/com/fortify/fod/parser/FortifyCommands.java
+++ b/src/main/java/com/fortify/fod/parser/FortifyCommands.java
@@ -103,6 +103,12 @@ public class FortifyCommands {
             description = "whether to exclude third party libraries")
     public boolean excludeThirdPartyLibs = false;
 
+    private static final String INCLUDE_THIRD_PARTY_LIBS = "-includeThirdPartyApps";
+    private static final String INCLUDE_THIRD_PARTY_LIBS_SHORT = "-itp";
+    @Parameter(names = { INCLUDE_THIRD_PARTY_LIBS, INCLUDE_THIRD_PARTY_LIBS_SHORT },
+            description = "whether to include third party libraries")
+    public boolean includeThirdPartyLibs = false;
+
     private static final String IS_REMEDIATION_SCAN = "-isRemediationScan";
     private static final String IS_REMEDIATION_SCAN_SHORT = "--r";
     @Parameter(names = { IS_REMEDIATION_SCAN, IS_REMEDIATION_SCAN_SHORT },
@@ -140,7 +146,6 @@ public class FortifyCommands {
             arity = 5,
             variableArity = true)
     public List<String> proxy = new ArrayList<>();
-
 
     public void version() {
         Package p = getClass().getPackage();


### PR DESCRIPTION
Obsoleted the `-x` flag in favor of the caller opting into the 3rd Party Component scan with the `-itp` flag.

Fix for #14 