### PR TITLE
Update build.gradle to use Gradle 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
-        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
     }
 }
 
@@ -44,8 +43,12 @@ shadowJar {
 jar {
     manifest {
         attributes("Main-Class": "com.fortify.fod.Main",
-                "Implementation-Version": version)
+                "Implementation-Version": archiveVersion)
     }
+}
+
+test {
+    useJUnitPlatform()
 }
 
 task logError {

--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,10 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.0.0'
 }
 
+configurations.implementation.setCanBeResolved(true)
+
 shadowJar {
-    classifier = null
-    configurations = [project.configurations.compile]
-    archiveName = "${baseName}.${extension}"
+    archiveVersion.set('')
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,7 @@ buildscript {
 
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
-apply plugin: 'maven'
-apply plugin: 'org.junit.platform.gradle.plugin'
+apply plugin: 'maven-publish'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -22,15 +22,15 @@ repositories {
     jcenter()
 }
 dependencies {
-    compile group: 'commons-io', name: 'commons-io', version: '2.5'
-    compile group: 'com.squareup.okio', name: 'okio', version: '1.10.0'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.9.0'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
-    compile 'com.fortify.fod:BSITokenParser:1.1.0'
-    compile 'com.beust:jcommander:1.48'
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0'
-    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.0'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
+    implementation group: 'com.squareup.okio', name: 'okio', version: '1.10.0'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.9.0'
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.7'
+    implementation 'com.fortify.fod:BSITokenParser:1.1.0'
+    implementation 'com.beust:jcommander:1.48'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.0.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.0.0'
 }
 
 shadowJar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip


### PR DESCRIPTION
This project is using ancient Gradle 3 which does not support modern Java versions and it also not supported by the Gradle project itself. Converting to Gradle 6 meant:

- Using native junit support instead of deprecated plugin
- Use new dependency configuration names instead of deprecated ones
- Use maven-publish instead of deprecated maven
- Some reconfiguration of the shadow plugin (simplified) to work with latest version

All tests pass - I still need to do an actual test upload to FOD as well to ensure that part works. However, should this PR be desired, I encourage the maintainers of fod-uploader-java to also do their own (possibly more in-depth) actual upload tests.