### PR TITLE
Possible fix for binary scan issue on version 5.3.0

### DIFF
--- a/src/main/java/com/fortify/fod/fodapi/controllers/ReleaseController.java
+++ b/src/main/java/com/fortify/fod/fodapi/controllers/ReleaseController.java
@@ -225,7 +225,7 @@ public class ReleaseController extends ControllerBase {
             pss.auditPreferenceType = fc.auditPreferenceType != null ? fc.auditPreferenceType : FodEnums.AuditPreferenceTypes.fromInt(scanSettingsDTO.getauditPreferenceType());
             pss.entitlementFrequencyType = null;
             pss.performOpenSourceAnalysis = fc.runOpenSourceScan ? fc.runOpenSourceScan : scanSettingsDTO.getPerformOpenSourceAnalysis();
-            pss.scanBinary = fc.isBinaryScan ? fc.isBinaryScan : scanSettingsDTO.getScanBinary();
+            pss.scanBinary = fc.isBinaryScan ? scanSettingsDTO.getScanBinary() : fc.isBinaryScan;
             pss.includeThirdPartyLibraries = fc.includeThirdPartyLibs ? fc.includeThirdPartyLibs : scanSettingsDTO.getincludeThirdPartyLibraries();
             pss.useSourceControl = false;
             if(fc.technologyStack > 0){


### PR DESCRIPTION
Changed the order on the binary scan comparison: you only lookup the configuration if the binary scan flag is true (it is false by default in the uploader, but it's undefined on the portal if there's no explicit config on the tenant). 
Please see issue https://github.com/fod-dev/fod-uploader-java/issues/90