### PR TITLE
Update exit code return values of help and version

### DIFF
--- a/src/main/java/com/fortify/fod/Main.java
+++ b/src/main/java/com/fortify/fod/Main.java
@@ -27,12 +27,12 @@ public class Main {
 
         if (fc.version) {
             fc.version();
-            System.exit(1);
+            System.exit(0);
         }
 
         if (fc.help) {
             jc.usage();
-            System.exit(1);
+            System.exit(0);
         }
 
         if (fc.bsiToken == null && (fc.isEmptyParameter(fc.portalUrl) || !fc.isValidUrl(fc.portalUrl)))


### PR DESCRIPTION
At present, invoking the FodUpload.jar via the command line and passing options for version or help (i.e. java -jar FodUpload.jar -v) results in an exit status of 1, rather than the expected successful exit status of 0.
Updating the exit code returned to 0 (successful) when passing the help and version options.